### PR TITLE
minor tweaks to new CRUD methods

### DIFF
--- a/packages/arcgis-rest-common-types/src/index.ts
+++ b/packages/arcgis-rest-common-types/src/index.ts
@@ -84,7 +84,7 @@ export interface IEnvelope extends IGeometry {
 /**
  *
  */
-export type esriGeometryType =
+export type esriGeometryType =  // why is this type camelCased?
   | "esriGeometryPoint"
   | "esriGeometryMultipoint"
   | "esriGeometryPolyline"
@@ -92,9 +92,9 @@ export type esriGeometryType =
   | "esriGeometryEnvelope";
 
 /**
- *
+ * The spatial relationship used to compare input geometries
  */
-export type spatialRel =
+export type SpatialRelationship =
   | "esriSpatialRelIntersects"
   | "esriSpatialRelContains"
   | "esriSpatialRelCrosses"

--- a/packages/arcgis-rest-feature-service/src/features.ts
+++ b/packages/arcgis-rest-feature-service/src/features.ts
@@ -270,7 +270,7 @@ export interface IDeleteFeaturesParams extends ICrudFeaturesParams {
  */
 export interface IDeleteFeaturesRequestOptions extends IRequestOptions {
   url: string;
-  objectIds: number[];
+  deletes: number[];
   params?: IDeleteFeaturesParams;
 }
 
@@ -299,7 +299,7 @@ export function deleteFeatures(
   };
 
   // mixin, don't overwrite
-  options.params.objectIds = requestOptions.objectIds;
+  options.params.objectIds = requestOptions.deletes;
 
   return request(url, options);
 }

--- a/packages/arcgis-rest-feature-service/test/features.test.ts
+++ b/packages/arcgis-rest-feature-service/test/features.test.ts
@@ -160,7 +160,7 @@ describe("feature", () => {
     const requestOptions = {
       url:
         "https://services.arcgis.com/V6ZHFr6zdgNZuVG0/arcgis/rest/services/Landscape_Trees/FeatureServer/0",
-      objectIds: [1001],
+      deletes: [1001],
       params: {
         where: "1=1"
       }
@@ -174,7 +174,7 @@ describe("feature", () => {
       expect(options.body).toContain("where=1%3D1");
       expect(options.method).toBe("POST");
       expect(deleteFeaturesResponse.deleteResults[0].objectId).toEqual(
-        requestOptions.objectIds[0]
+        requestOptions.deletes[0]
       );
       expect(deleteFeaturesResponse.deleteResults[0].success).toEqual(true);
       done();


### PR DESCRIPTION
* ensure tests introspect the request parameters that are sent (and not just the canned response)
* makes `adds`, `updates` and `deletes` genuine _first-class citizens_ to make the typical client signature more ergonomic
* make the new `type` name more verbose (and capitalized)
* add optional parameters to a few tests to confirm they are passed through appropriately
* extend `IParams` to make it possible to tack generic params onto the new typed interfaces

let me know what you think.